### PR TITLE
Wow dialog fix

### DIFF
--- a/HBPlugin/HBRelogHelper.cs
+++ b/HBPlugin/HBRelogHelper.cs
@@ -194,7 +194,7 @@ namespace HighVoltz.HBRelogHelper
         {
             try
             {
-                if (!IsConnected)
+                if (!IsConnected || ProfileState != ProfileState.Running)
                     return;
 
                 if (TreeRoot.StatusText != _lastStatus && !string.IsNullOrEmpty(TreeRoot.StatusText))
@@ -212,7 +212,6 @@ namespace HighVoltz.HBRelogHelper
                 CheckWowHealth();
                 if (GameStats.IsMeasuring)
                     UpdateTooltip();
-
             }
             catch (Exception ex)
             {
@@ -317,6 +316,8 @@ namespace HighVoltz.HBRelogHelper
             }
         }
 
+        private static ProfileState ProfileState => (ProfileState) HBRelogApi.GetProfileStatus(HBRelogApi.CurrentProfileName);
+
         private static void Log(string msg)
         {
             Logging.Write("HBRelogHelper: " + msg);
@@ -406,6 +407,14 @@ namespace HighVoltz.HBRelogHelper
         LoggedOutForTooLong,
     }
 
+    internal enum ProfileState
+    {
+        None,
+        Paused,
+        Running,
+        Stopped
+    }
+
     internal static class NativeMethods
     {
         public delegate bool EnumWindowProc(IntPtr hWnd, IntPtr parameter);
@@ -490,4 +499,5 @@ namespace HighVoltz.HBRelogHelper
             HBRelogRemoteApi.SkipCurrentTask(profileName);
         }
     }
+
 }

--- a/Remoting/RemotingApi.cs
+++ b/Remoting/RemotingApi.cs
@@ -201,7 +201,13 @@ namespace HighVoltz.HBRelog.Remoting
 			CharacterProfile profile = GetProfileByName(profileName);
 			if (profile != null)
 			{
-				BMTask currentTask = profile.TaskManager.CurrentTask;
+                if (!profile.IsRunning || profile.IsPaused)
+                {
+                    profile.Log("Could not skip current task because profile is not running or is paused.");
+                    return;
+                }
+
+                BMTask currentTask = profile.TaskManager.CurrentTask;
 				if (currentTask == null)
 				{
 					profile.Log("Could not skip current task because there is no task running.");

--- a/WoW/States/CharacterSelectState.cs
+++ b/WoW/States/CharacterSelectState.cs
@@ -156,7 +156,9 @@ namespace HighVoltz.HBRelog.WoW.States
                 _wowManager.CloseGameProcess();
                 return;
             }
-
+            // Inserts a delay before pressing button because pressing too fast causes the 'You have been disconnected' error.
+            // See https://github.com/BosslandGmbH/HBRelog/issues/49
+            Thread.Sleep(4000);
             var changeRealmButton = UIObject.GetUIObjectByName<Button>(_wowManager, "CharSelectChangeRealmButton");
             var clickPos = _wowManager.ConvertWidgetCenterToWin32Coord(changeRealmButton);
             Utility.LeftClickAtPos(_wowManager.GameWindow, (int)clickPos.X, (int)clickPos.Y);

--- a/WoW/WowLockToken.cs
+++ b/WoW/WowLockToken.cs
@@ -158,7 +158,7 @@ namespace HighVoltz.HBRelog.WoW
                     else if (_dialogDisplayTimer.ElapsedMilliseconds > 30000)
                     {
                         _lockOwner.Profile.Log($"WoW v{_wowProcess.VersionString()} failed to load and is a popup. " +
-                            $"Make sure your WoW installation is updated. Pausing profile.");
+                            $"Make sure your WoW installation is updated and WoW is using windowed mode. Pausing profile.");
                         _lockOwner.Profile.Pause();
                         ReleaseLock();
                     }

--- a/WoW/WowLockToken.cs
+++ b/WoW/WowLockToken.cs
@@ -155,7 +155,7 @@ namespace HighVoltz.HBRelog.WoW
                     {
                         _dialogDisplayTimer = Stopwatch.StartNew();
                     }
-                    else if (_dialogDisplayTimer.ElapsedMilliseconds > 10000)
+                    else if (_dialogDisplayTimer.ElapsedMilliseconds > 30000)
                     {
                         _lockOwner.Profile.Log($"WoW v{_wowProcess.VersionString()} failed to load and is a popup. " +
                             $"Make sure your WoW installation is updated. Pausing profile.");


### PR DESCRIPTION
* SkipCurrentTask will now only skip if profile is running and not paused.
* HBRelog no longer closes WoW because of disconnection or logged out
for too long when profile is paused
* User is asked to make sure WoW running in windowed mode when the 'WoW
is a dialog' error is shown.
* Added a delay before pressing the 'Change Realm' button to avoid the infamous 'You have been disconnected' error. Fixes #49