### PR TITLE
Misc

### DIFF
--- a/MinRequiredVersion.txt
+++ b/MinRequiredVersion.txt
@@ -1,0 +1,1 @@
+﻿1.1.20 - This version is required to launch the new Honorbuddy for WoW 7.3

--- a/WoW/WowLockToken.cs
+++ b/WoW/WowLockToken.cs
@@ -155,7 +155,7 @@ namespace HighVoltz.HBRelog.WoW
                     {
                         _dialogDisplayTimer = Stopwatch.StartNew();
                     }
-                    else if (_dialogDisplayTimer.ElapsedMilliseconds > 30000)
+                    else if (_dialogDisplayTimer.ElapsedMilliseconds > 10000)
                     {
                         _lockOwner.Profile.Log($"WoW v{_wowProcess.VersionString()} failed to load and is a popup. " +
                             $"Make sure your WoW installation is updated and WoW is using windowed mode. Pausing profile.");


### PR DESCRIPTION
* Added a 'MinRequiredVersion.txt' file that HBRelog will read on start and periodically during run-time to determine to determine whether the running HBRelog needs an update

* The WoW dialog display timer has been reverted back to 10 seconds because this seems sufficient