### PR TITLE
Minimum version check, and 'Resize' and 'Grab' button fix

### DIFF
--- a/Controls/ProfileEditUserControl.xaml.cs
+++ b/Controls/ProfileEditUserControl.xaml.cs
@@ -135,7 +135,7 @@ namespace HighVoltz.HBRelog.Controls
             if (MainWindow.Instance.AccountGrid.SelectedItem != null)
             {
                 CharacterProfile profile = (CharacterProfile)MainWindow.Instance.AccountGrid.SelectedItem;
-                if (profile.TaskManager.WowManager.Memory != null)
+                if (profile.TaskManager.WowManager.GameWindow != IntPtr.Zero)
                 {
                     var Rect = Utility.GetWindowRect(profile.TaskManager.WowManager.GameWindow);
                     profile.Settings.WowSettings.WowWindowX = Rect.Left;
@@ -226,7 +226,7 @@ namespace HighVoltz.HBRelog.Controls
             if (MainWindow.Instance.AccountGrid.SelectedItem != null)
             {
                 CharacterProfile profile = (CharacterProfile)MainWindow.Instance.AccountGrid.SelectedItem;
-                if (profile.TaskManager.WowManager.Memory != null)
+                if (profile.TaskManager.WowManager.GameWindow != IntPtr.Zero)
                 {
                     var screen = Screen.FromHandle(profile.TaskManager.WowManager.GameWindow);
                     try

--- a/HBRelog.csproj
+++ b/HBRelog.csproj
@@ -80,6 +80,9 @@
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
+    <Reference Include="System.Runtime" />
+    <Reference Include="System.Globalization" />
+    <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Extensions.cs" />
@@ -297,6 +300,7 @@
     <Content Include="bin\Debug\HBRelog.pdb" />
     <Content Include="bin\Release\fasmdll_managed.dll" />
     <Content Include="bin\Release\HBRelog.exe" />
+    <Resource Include="MinRequiredVersion.txt" />
     <None Include="CREDITS.md">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/HBRelogManager.cs
+++ b/HBRelogManager.cs
@@ -22,10 +22,12 @@ using System.ServiceModel;
 using System.Windows;
 using System.ComponentModel;
 using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
 
 namespace HighVoltz.HBRelog
 {
-    class HbRelogManager
+    internal class HbRelogManager
     {
         public static GlobalSettings Settings => GlobalSettings.Instance;
 	    static public Thread WorkerThread { get; private set; }
@@ -71,7 +73,7 @@ namespace HighVoltz.HBRelog
             }
         }
 
-        static void DoWork()
+        internal static void DoWork()
         {
             int pulseStartTime = 0;
             while (true)

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -187,7 +187,14 @@
                                             <EventSetter Event="Click" Handler="KillHbMenuItem_Click" />
                                         </Style>
                                     </MenuItem.Style>
-                                </MenuItem>                                
+                                </MenuItem>
+                                <MenuItem  x:Name="BringWoWToForeground" Header="Bring WoW To Foreground"  Tag="{Binding}">
+                                    <MenuItem.Style>
+                                        <Style TargetType="{x:Type MenuItem}" BasedOn="{StaticResource  {x:Type MenuItem}}">
+                                            <EventSetter Event="Click" Handler="BringWoWToForeground_Click" />
+                                        </Style>
+                                    </MenuItem.Style>
+                                </MenuItem>
                             </ContextMenu>
                         </Setter.Value>
                     </Setter>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -331,6 +331,13 @@ namespace HighVoltz.HBRelog
             hbManager.CloseBotProcess();
         }
 
+
+        private void BringWoWToForeground_Click(object sender, RoutedEventArgs e)
+        {
+            var wowManager = ((CharacterProfile)((MenuItem)sender).Tag).TaskManager.WowManager;
+            Utility.BringWindowIntoFocus(wowManager.GameWindow, wowManager.Profile);
+        }
+
         private void DataGridRowContextMenuOpening(object sender, ContextMenuEventArgs e)
         {
             var row = (DataGridRow)sender;
@@ -360,6 +367,11 @@ namespace HighVoltz.HBRelog
                 bringHbToForegroundTaskMenuItem.Visibility = Visibility.Collapsed;
                 killHBMenu.Visibility = Visibility.Collapsed;
             }
+
+            var bringWowToForegroundMenu = (MenuItem)row.ContextMenu.Items[3];
+            bringWowToForegroundMenu.Visibility = wowManager.IsRunning && wowManager.GameWindow != IntPtr.Zero 
+                ? Visibility.Visible
+                : Visibility.Collapsed;
         }
 
         private const string s_minRequireVersionUrl = "https://raw.githubusercontent.com/BosslandGmbH/HBRelog/master/MinRequiredVersion.txt";

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -26,6 +26,11 @@ using System.Windows.Input;
 using System.Windows.Media.Animation;
 using HighVoltz.HBRelog.Settings;
 using HighVoltz.HBRelog.Tasks;
+using System.Threading.Tasks;
+using System.Net;
+using System.IO;
+using System.Diagnostics;
+using System.Windows.Threading;
 
 namespace HighVoltz.HBRelog
 {
@@ -35,6 +40,7 @@ namespace HighVoltz.HBRelog
     public partial class MainWindow : Window
     {
         private Timer _autoCloseTimer;
+        private DispatcherTimer _minVersionCheckTimer;
 
         public MainWindow()
         {
@@ -149,7 +155,7 @@ namespace HighVoltz.HBRelog
             }
         }
 
-        private void Window_Loaded(object sender, RoutedEventArgs e)
+        private async void Window_Loaded(object sender, RoutedEventArgs e)
         {
             OptionsTab.IsSelected = false;
             Version version = Assembly.GetExecutingAssembly().GetName().Version;
@@ -168,6 +174,17 @@ namespace HighVoltz.HBRelog
 			Log.Write("\t{0,-30} {1}", "Set GameWindow Title:", HbRelogManager.Settings.SetGameWindowTitle);
             Log.Write("\t{0,-30} {1}", "Wow Start Delay:", HbRelogManager.Settings.WowDelay);
 
+            // prevent user from starting any profiles until after version check is complete
+            Log.Write("Checking minimum required version.");
+            StartButton.IsEnabled = false;
+            await CheckMinimumRequiredVersion();
+
+            _minVersionCheckTimer = new DispatcherTimer();
+            _minVersionCheckTimer.Tick += MinVersionCheckTimer_Tick;
+            _minVersionCheckTimer.Interval = TimeSpan.FromMinutes(5);
+            _minVersionCheckTimer.Start();
+
+            StartButton.IsEnabled = true;
 
             string rawProfilesToStart;
 
@@ -343,6 +360,41 @@ namespace HighVoltz.HBRelog
                 bringHbToForegroundTaskMenuItem.Visibility = Visibility.Collapsed;
                 killHBMenu.Visibility = Visibility.Collapsed;
             }
+        }
+
+        private const string s_minRequireVersionUrl = "https://raw.githubusercontent.com/BosslandGmbH/HBRelog/master/MinRequiredVersion.txt";
+
+        private async void MinVersionCheckTimer_Tick(object sender, EventArgs e)
+        {
+            await CheckMinimumRequiredVersion();
+        }
+
+        private async Task CheckMinimumRequiredVersion()
+        {
+            var webClient = new WebClient();
+            var text = await webClient.DownloadStringTaskAsync(s_minRequireVersionUrl);
+            if (string.IsNullOrEmpty(text))
+                throw new InvalidDataException("Remote MinRequiredVersion.txt is empty.");
+            text = text.Trim();
+            var firstSpaceI = text.IndexOf(" ");
+            var versionTxt = firstSpaceI == -1 ? text : text.Substring(0, firstSpaceI);
+            var minVersion = Version.Parse(versionTxt);
+            var msg = firstSpaceI > 0 ? text.Substring(firstSpaceI + 1) : null;
+            var currentVersion = Version.Parse(Process.GetCurrentProcess().VersionString());
+            if (currentVersion.Major >= minVersion.Major && currentVersion.Minor >= minVersion.Minor && currentVersion.Build >= minVersion.Build)
+                return;
+
+            foreach (CharacterProfile profile in AccountGrid.Items)
+            {
+                if (profile.IsRunning)
+                    profile.Stop();
+            }
+
+            msg = $"Your HBRelog version {currentVersion} is no longer compatible or safe. " +
+                $"You need upgrade to version {minVersion} or higher.{(msg != null ?" " + msg : "")}";
+
+            MessageBox.Show(msg, "Incompatible HBRelog Version");
+            Process.GetCurrentProcess().Kill();
         }
     }
 }

--- a/MinRequiredVersion.txt
+++ b/MinRequiredVersion.txt
@@ -1,1 +1,1 @@
-﻿1.1.20 This version is required to launch the new Honorbuddy for WoW 7.3
+﻿﻿1.1.20 This version is required to launch the new Honorbuddy for WoW 7.3

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -51,5 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.19")]
-[assembly: AssemblyFileVersion("1.1.19")]
+[assembly: AssemblyVersion("1.1.20")]
+[assembly: AssemblyFileVersion("1.1.20")]

--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace HighVoltz.HBRelog.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "14.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.1.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));


### PR DESCRIPTION
* The minimum required version of HBRelog is now checked on startup and periodically during run-time.
* The 'Grab' and 'Resize' buttons in the 'Window' tab have been fixed.
This fixes issue #52.